### PR TITLE
Fix the type signature for addEventListener

### DIFF
--- a/dependencies/Control/Monad/Eff/DOM.purs
+++ b/dependencies/Control/Monad/Eff/DOM.purs
@@ -126,4 +126,4 @@ foreign import addEventListener
   \      };\
   \    };\
   \  };\
-  \}" :: forall eff. String -> Eff (dom :: DOM | eff) Unit -> Node -> Eff (dom :: DOM | eff) Node 
+  \}" :: forall eff. String -> Eff (dom :: DOM | eff) Unit -> Node -> Eff (dom :: DOM | eff) Unit 


### PR DESCRIPTION
The function addEventListener defines an effect that returns nothing.
Reflecting that in the type signature.
