### PR TITLE
Update Hashable.purs

### DIFF
--- a/chapter6/src/Data/Hashable.purs
+++ b/chapter6/src/Data/Hashable.purs
@@ -13,7 +13,7 @@ import Data.Maybe
 import Data.Tuple
 import Data.Either
 import Data.String
-import Data.Char
+import Data.Char (toCharCode)
 import Data.Function (on)
 import Data.Foldable (foldMap)
 import Data.Monoid (Monoid)


### PR DESCRIPTION
fix that conflicting imports for `toUpper` and `toLower` from modules `Data.Char` and `Data.String`.