### PR TITLE
Add psc-package.json files for all chapter exercises

### DIFF
--- a/exercises/chapter10/psc-package.json
+++ b/exercises/chapter10/psc-package.json
@@ -1,0 +1,16 @@
+{
+  "name": "purescript-book-chapter10",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "console",
+    "dom",
+    "foreign",
+    "foreign-generic",
+    "psci-support",
+    "react",
+    "react-dom",
+    "strings",
+    "validation"
+  ]
+}

--- a/exercises/chapter11/psc-package.json
+++ b/exercises/chapter11/psc-package.json
@@ -1,0 +1,14 @@
+{
+  "name": "purescript-book-chapter11",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "maps",
+    "node-readline",
+    "sets",
+    "strings",
+    "transformers",
+    "psci-support",
+    "yargs"
+  ]
+}

--- a/exercises/chapter12/psc-package.json
+++ b/exercises/chapter12/psc-package.json
@@ -1,0 +1,15 @@
+{
+  "name": "purescript-book-chapter12",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "console",
+    "functions",
+    "lists",
+    "parallel",
+    "psci-support",
+    "refs",
+    "strings",
+    "transformers"
+  ]
+}

--- a/exercises/chapter13/psc-package.json
+++ b/exercises/chapter13/psc-package.json
@@ -1,0 +1,12 @@
+{
+  "name": "purescript-book-chapter13",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "arrays",
+    "functions",
+    "lists",
+    "psci-support",
+    "quickcheck"
+  ]
+}

--- a/exercises/chapter14/psc-package.json
+++ b/exercises/chapter14/psc-package.json
@@ -1,0 +1,11 @@
+{
+  "name": "purescript-book-chapter14",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "arrays",
+    "free",
+    "psci-support",
+    "strings"
+  ]
+}

--- a/exercises/chapter2/psc-package.json
+++ b/exercises/chapter2/psc-package.json
@@ -1,0 +1,10 @@
+{
+  "name": "purescript-book-chapter2",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "console",
+    "math",
+    "psci-support"
+  ]
+}

--- a/exercises/chapter3/psc-package.json
+++ b/exercises/chapter3/psc-package.json
@@ -1,0 +1,10 @@
+{
+  "name": "purescript-book-chapter3",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "console",
+    "lists",
+    "psci-support"
+  ]
+}

--- a/exercises/chapter4/psc-package.json
+++ b/exercises/chapter4/psc-package.json
@@ -1,0 +1,11 @@
+{
+  "name": "purescript-book-chapter4",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "arrays",
+    "console",
+    "psci-support",
+    "strings"
+  ]
+}

--- a/exercises/chapter5/psc-package.json
+++ b/exercises/chapter5/psc-package.json
@@ -1,0 +1,12 @@
+{
+  "name": "purescript-book-chapter5",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "arrays",
+    "console",
+    "globals",
+    "psci-support",
+    "math"
+  ]
+}

--- a/exercises/chapter6/psc-package.json
+++ b/exercises/chapter6/psc-package.json
@@ -1,0 +1,13 @@
+{
+  "name": "purescript-book-chapter6",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "console",
+    "either",
+    "functions",
+    "psci-support",
+    "strings",
+    "tuples"
+  ]
+}

--- a/exercises/chapter7/psc-package.json
+++ b/exercises/chapter7/psc-package.json
@@ -1,0 +1,14 @@
+{
+  "name": "purescript-book-chapter7",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "arrays",
+    "console",
+    "either",
+    "functions",
+    "psci-support",
+    "strings",
+    "validation"
+  ]
+}

--- a/exercises/chapter8/psc-package.json
+++ b/exercises/chapter8/psc-package.json
@@ -1,0 +1,15 @@
+{
+  "name": "purescript-book-chapter8",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "console",
+    "dom",
+    "foreign",
+    "random",
+    "react",
+    "react-dom",
+    "strings",
+    "validation"
+  ]
+}

--- a/exercises/chapter9/psc-package.json
+++ b/exercises/chapter9/psc-package.json
@@ -1,0 +1,16 @@
+{
+  "name": "purescript-book-chapter9",
+  "set": "psc-0.11.7",
+  "source": "https://github.com/purescript/package-sets.git",
+  "depends": [
+    "arrays",
+    "canvas",
+    "console",
+    "dom",
+    "lists",
+    "math",
+    "psci-support",
+    "random",
+    "refs"
+  ]
+}


### PR DESCRIPTION
Verified that all exercise projects compile using the package set.

I had to add a missing dependency on `-random` for chapter 8.